### PR TITLE
Update install instructions to use the right /

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Simple cross-platform pure Go screen shot library. (tested only on linux&windows
 
 
 ## Install:
-go get github.com\vova616\screenshot
+go get github.com/vova616/screenshot
 
 ## Dependencies:
 Windows: https://github.com/AllenDang/w32


### PR DESCRIPTION
When copying and pasting, the \ gets translated to an escape. I just fixed the direction so it's / now instead of . 
