### PR TITLE
Copy relevant code from w32

### DIFF
--- a/screenshot_windows.go
+++ b/screenshot_windows.go
@@ -2,20 +2,20 @@ package screenshot
 
 import (
 	"fmt"
-	"github.com/AllenDang/w32"
 	"image"
 	"reflect"
+	"syscall"
 	"unsafe"
 )
 
 func ScreenRect() (image.Rectangle, error) {
-	hDC := w32.GetDC(0)
+	hDC := GetDC(0)
 	if hDC == 0 {
-		return image.Rectangle{}, fmt.Errorf("Could not Get primary display err:%d\n", w32.GetLastError())
+		return image.Rectangle{}, fmt.Errorf("Could not Get primary display err:%d\n", GetLastError())
 	}
-	defer w32.ReleaseDC(0, hDC)
-	x := w32.GetDeviceCaps(hDC, w32.HORZRES)
-	y := w32.GetDeviceCaps(hDC, w32.VERTRES)
+	defer ReleaseDC(0, hDC)
+	x := GetDeviceCaps(hDC, HORZRES)
+	y := GetDeviceCaps(hDC, VERTRES)
 	return image.Rect(0, 0, x, y), nil
 }
 
@@ -28,50 +28,50 @@ func CaptureScreen() (*image.RGBA, error) {
 }
 
 func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
-	hDC := w32.GetDC(0)
+	hDC := GetDC(0)
 	if hDC == 0 {
-		return nil, fmt.Errorf("Could not Get primary display err:%d.\n", w32.GetLastError())
+		return nil, fmt.Errorf("Could not Get primary display err:%d.\n", GetLastError())
 	}
-	defer w32.ReleaseDC(0, hDC)
+	defer ReleaseDC(0, hDC)
 
-	m_hDC := w32.CreateCompatibleDC(hDC)
+	m_hDC := CreateCompatibleDC(hDC)
 	if m_hDC == 0 {
-		return nil, fmt.Errorf("Could not Create Compatible DC err:%d.\n", w32.GetLastError())
+		return nil, fmt.Errorf("Could not Create Compatible DC err:%d.\n", GetLastError())
 	}
-	defer w32.DeleteDC(m_hDC)
+	defer DeleteDC(m_hDC)
 
 	x, y := rect.Dx(), rect.Dy()
 
-	bt := w32.BITMAPINFO{}
+	bt := BITMAPINFO{}
 	bt.BmiHeader.BiSize = uint32(reflect.TypeOf(bt.BmiHeader).Size())
 	bt.BmiHeader.BiWidth = int32(x)
 	bt.BmiHeader.BiHeight = int32(-y)
 	bt.BmiHeader.BiPlanes = 1
 	bt.BmiHeader.BiBitCount = 32
-	bt.BmiHeader.BiCompression = w32.BI_RGB
+	bt.BmiHeader.BiCompression = BI_RGB
 
 	ptr := unsafe.Pointer(uintptr(0))
 
-	m_hBmp := w32.CreateDIBSection(m_hDC, &bt, w32.DIB_RGB_COLORS, &ptr, 0, 0)
+	m_hBmp := CreateDIBSection(m_hDC, &bt, DIB_RGB_COLORS, &ptr, 0, 0)
 	if m_hBmp == 0 {
-		return nil, fmt.Errorf("Could not Create DIB Section err:%d.\n", w32.GetLastError())
+		return nil, fmt.Errorf("Could not Create DIB Section err:%d.\n", GetLastError())
 	}
-	if m_hBmp == w32.InvalidParameter {
+	if m_hBmp == InvalidParameter {
 		return nil, fmt.Errorf("One or more of the input parameters is invalid while calling CreateDIBSection.\n")
 	}
-	defer w32.DeleteObject(w32.HGDIOBJ(m_hBmp))
+	defer DeleteObject(HGDIOBJ(m_hBmp))
 
-	obj := w32.SelectObject(m_hDC, w32.HGDIOBJ(m_hBmp))
+	obj := SelectObject(m_hDC, HGDIOBJ(m_hBmp))
 	if obj == 0 {
-		return nil, fmt.Errorf("error occurred and the selected object is not a region err:%d.\n", w32.GetLastError())
+		return nil, fmt.Errorf("error occurred and the selected object is not a region err:%d.\n", GetLastError())
 	}
-	if obj == 0xffffffff { //GDI_ERROR 
-		return nil, fmt.Errorf("GDI_ERROR while calling SelectObject err:%d.\n", w32.GetLastError())
+	if obj == 0xffffffff { //GDI_ERROR
+		return nil, fmt.Errorf("GDI_ERROR while calling SelectObject err:%d.\n", GetLastError())
 	}
-	defer w32.DeleteObject(obj)
+	defer DeleteObject(obj)
 
 	//Note:BitBlt contains bad error handling, we will just assume it works and if it doesn't it will panic :x
-	w32.BitBlt(m_hDC, 0, 0, x, y, hDC, rect.Min.X, rect.Min.Y, w32.SRCCOPY)
+	BitBlt(m_hDC, 0, 0, x, y, hDC, rect.Min.X, rect.Min.Y, SRCCOPY)
 
 	var slice []byte
 	hdrp := (*reflect.SliceHeader)(unsafe.Pointer(&slice))
@@ -88,3 +88,156 @@ func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
 	img := &image.RGBA{imageBytes, 4 * x, image.Rect(0, 0, x, y)}
 	return img, nil
 }
+
+func GetDeviceCaps(hdc HDC, index int) int {
+	ret, _, _ := procGetDeviceCaps.Call(
+		uintptr(hdc),
+		uintptr(index))
+
+	return int(ret)
+}
+
+func GetDC(hwnd HWND) HDC {
+	ret, _, _ := procGetDC.Call(
+		uintptr(hwnd))
+
+	return HDC(ret)
+}
+
+func ReleaseDC(hwnd HWND, hDC HDC) bool {
+	ret, _, _ := procReleaseDC.Call(
+		uintptr(hwnd),
+		uintptr(hDC))
+
+	return ret != 0
+}
+
+func DeleteDC(hdc HDC) bool {
+	ret, _, _ := procDeleteDC.Call(
+		uintptr(hdc))
+
+	return ret != 0
+}
+
+func GetLastError() uint32 {
+	ret, _, _ := procGetLastError.Call()
+	return uint32(ret)
+}
+
+func BitBlt(hdcDest HDC, nXDest, nYDest, nWidth, nHeight int, hdcSrc HDC, nXSrc, nYSrc int, dwRop uint) {
+	ret, _, _ := procBitBlt.Call(
+		uintptr(hdcDest),
+		uintptr(nXDest),
+		uintptr(nYDest),
+		uintptr(nWidth),
+		uintptr(nHeight),
+		uintptr(hdcSrc),
+		uintptr(nXSrc),
+		uintptr(nYSrc),
+		uintptr(dwRop))
+
+	if ret == 0 {
+		panic("BitBlt failed")
+	}
+}
+
+func SelectObject(hdc HDC, hgdiobj HGDIOBJ) HGDIOBJ {
+	ret, _, _ := procSelectObject.Call(
+		uintptr(hdc),
+		uintptr(hgdiobj))
+
+	if ret == 0 {
+		panic("SelectObject failed")
+	}
+
+	return HGDIOBJ(ret)
+}
+
+func DeleteObject(hObject HGDIOBJ) bool {
+	ret, _, _ := procDeleteObject.Call(
+		uintptr(hObject))
+
+	return ret != 0
+}
+
+func CreateDIBSection(hdc HDC, pbmi *BITMAPINFO, iUsage uint, ppvBits *unsafe.Pointer, hSection HANDLE, dwOffset uint) HBITMAP {
+	ret, _, _ := procCreateDIBSection.Call(
+		uintptr(hdc),
+		uintptr(unsafe.Pointer(pbmi)),
+		uintptr(iUsage),
+		uintptr(unsafe.Pointer(ppvBits)),
+		uintptr(hSection),
+		uintptr(dwOffset))
+
+	return HBITMAP(ret)
+}
+
+func CreateCompatibleDC(hdc HDC) HDC {
+	ret, _, _ := procCreateCompatibleDC.Call(
+		uintptr(hdc))
+
+	if ret == 0 {
+		panic("Create compatible DC failed")
+	}
+
+	return HDC(ret)
+}
+
+type (
+	HANDLE  uintptr
+	HWND    HANDLE
+	HGDIOBJ HANDLE
+	HDC     HANDLE
+	HBITMAP HANDLE
+)
+
+type BITMAPINFO struct {
+	BmiHeader BITMAPINFOHEADER
+	BmiColors *RGBQUAD
+}
+
+type BITMAPINFOHEADER struct {
+	BiSize          uint32
+	BiWidth         int32
+	BiHeight        int32
+	BiPlanes        uint16
+	BiBitCount      uint16
+	BiCompression   uint32
+	BiSizeImage     uint32
+	BiXPelsPerMeter int32
+	BiYPelsPerMeter int32
+	BiClrUsed       uint32
+	BiClrImportant  uint32
+}
+
+type RGBQUAD struct {
+	RgbBlue     byte
+	RgbGreen    byte
+	RgbRed      byte
+	RgbReserved byte
+}
+
+const (
+	HORZRES          = 8
+	VERTRES          = 10
+	BI_RGB           = 0
+	InvalidParameter = 2
+	DIB_RGB_COLORS   = 0
+	SRCCOPY          = 0x00CC0020
+)
+
+var (
+	modgdi32               = syscall.NewLazyDLL("gdi32.dll")
+	moduser32              = syscall.NewLazyDLL("user32.dll")
+	modkernel32            = syscall.NewLazyDLL("kernel32.dll")
+	procGetDC              = moduser32.NewProc("GetDC")
+	procReleaseDC          = moduser32.NewProc("ReleaseDC")
+	procDeleteDC           = modgdi32.NewProc("DeleteDC")
+	procBitBlt             = modgdi32.NewProc("BitBlt")
+	procDeleteObject       = modgdi32.NewProc("DeleteObject")
+	procSelectObject       = modgdi32.NewProc("SelectObject")
+	procCreateDIBSection   = modgdi32.NewProc("CreateDIBSection")
+	procCreateCompatibleDC = modgdi32.NewProc("CreateCompatibleDC")
+	procGetDeviceCaps      = modgdi32.NewProc("GetDeviceCaps")
+	procGetLastError       = modkernel32.NewProc("GetLastError")
+)


### PR DESCRIPTION
Explanation: I was trying to debug https://github.com/AllenDang/w32/issues/57 and didn't get very far, but having `cgo` as a dependency made a build process of mine unpleasant (see http://dave.cheney.net/2016/01/18/cgo-is-not-go for details). Of course your screenshot library doesn't actually make use of any of the w32 parts that require cgo, so I figured I would eliminate the dependency.
