### PR TITLE
garbled screenshots on macOS when screen width is not divisible by 16

### DIFF
--- a/screenshot_darwin.go
+++ b/screenshot_darwin.go
@@ -9,6 +9,7 @@ import (
 	"image"
 	"reflect"
 	"unsafe"
+	"math"
 )
 
 func ScreenRect() (image.Rectangle, error) {
@@ -28,7 +29,7 @@ func CaptureScreen() (*image.RGBA, error) {
 
 func CaptureRect(rect image.Rectangle) (*image.RGBA, error) {
 	displayID := C.CGMainDisplayID()
-	width := int(C.CGDisplayPixelsWide(displayID))
+	width := int(math.Ceil(float64(C.CGDisplayPixelsWide(displayID))/16)*16)
 	rawData := C.CGDataProviderCopyData(C.CGImageGetDataProvider(C.CGDisplayCreateImage(displayID)))
 
 	length := int(C.CFDataGetLength(rawData))


### PR DESCRIPTION
see https://github.com/BoboTiG/python-mss/issues/14 for more details